### PR TITLE
Fix config in .mcp.json file

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "sail-operator": {
-      "type": "stdio",
-      "command": "/Users/frherrer/Documents/repos/mcp_sail_operator/mcp-sail-operator",
-      "args": [],
-      "env": {}
+      "command": "./mcp-sail-operator",
+      "args": []
     }
   }
 }


### PR DESCRIPTION
This would fix the following error if we try to run the "claude" CLI from the repo.

```
[DEBUG] MCP server "sail-operator": Error stack: Error: spawn /Users/frherrer/Documents/repos/mcp_sail_operator/mcp-sail-operator ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
[ERROR] MCP server "sail-operator" Connection failed: spawn /Users/frherrer/Documents/repos/mcp_sail_operator/mcp-sail-operator ENOENT
[DEBUG] MCP server "sail-operator": Connection attempt completed in 90ms - status: failed
```